### PR TITLE
Designated initializers for structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # C-Snake
 Python scripts for generating C/C++ code
 
-This project now supports generating static initializers for all kinds of variables, including arrays (multidimensional included). This is super useful for generating headers for bitmaps, fonts, statemachines, whatever.
-Only thing not supported as of now are designated inits for structs, but you can use regular array initializers for structs. Designated inits are coming soon.
+This project now supports generating static initializers for all kinds of variables, including arrays (multidimensional included). This is super useful for generating headers for bitmaps, fonts, statemachines, lookup tables, whatever.
+Designated initializers for structs are also supported.
 
 Refer to 'example.py' for an introduction to the script

--- a/csnake.py
+++ b/csnake.py
@@ -11,13 +11,15 @@ def shape(array):
     if isinstance(array, str):
         return ''
     curr = array
-    shape = []
+    shp = []
     while True:
+        if isinstance(curr, dict):
+            return shp
         try:
-            shape.append(len(curr))
+            shp.append(len(curr))
             curr = curr[0]
-        except TypeError:
-            return shape
+        except (TypeError, IndexError):
+            return shp
 
 
 ###############################################################################

--- a/csnake.py
+++ b/csnake.py
@@ -1,9 +1,7 @@
+# -*- coding: utf-8 -*-
 from datetime import date
 
-###############################################################################
-#                           public helper functions                           #
-###############################################################################
-
+# public helper functions
 
 def shape(array):
     """Return dimensions (shape) of a multidimensional list"""
@@ -22,10 +20,7 @@ def shape(array):
             return shp
 
 
-###############################################################################
-#                        classes defining C constructs                        #
-###############################################################################
-
+# classes defining C constructs
 
 class EnumValue:
     """Singular value of an C-style enumeration"""
@@ -275,10 +270,7 @@ class Function:
         return call_
 
 
-###############################################################################
-#                         Main, file-generating class                         #
-###############################################################################
-
+# Main, file-generating class
 
 class CodeWriter:
     """Class to describe and generate contents of a .c/.cpp/.h/.hpp file"""

--- a/csnake.py
+++ b/csnake.py
@@ -48,7 +48,7 @@ class Enum:
         self.prefix = prefix
 
     def add_value(self, name, value=None, comment=None):
-        """assuees that the user adds the values in the correct order"""
+        """assures that the user adds the values in the correct order"""
 
         self.values.append(EnumValue(name, value=value, comment=comment))
 

--- a/csnake.py
+++ b/csnake.py
@@ -158,6 +158,8 @@ class Variable:
                     if stack:
                         if isinstance(stack[-1], ClosedBrace):
                             output += '\n' + (indent * (depth - 1))
+                        elif isinstance(stack[-1], Designator):
+                            output += ','
                         else:
                             output += ',\n' + (indent * depth)
                         leading_comma = False

--- a/example.py
+++ b/example.py
@@ -120,10 +120,26 @@ var3 = Variable(
     comment=None,
     value=[[0 for _ in range(3)] for _ in range(3)],
     value_opts='{0:x}')
+var4 = Variable(
+    name='array_of_structs',
+    primitive='DatStructTho',
+    qualifiers='',
+    array=None,
+    comment=None,
+    value=[{
+        'a': [1, 2, 3, 4, 5],
+        'b': 13,
+        'c': 2.8
+    }, {
+        'a': [11, 23, 42, 5, 6],
+        'b': 53,
+        'c': 3.8
+    }])
 
 h.add_variable_declaration(var1, extern=True)
 h.add_variable_declaration(var2, extern=True)
 h.add_variable_declaration(var3, extern=True)
+h.add_variable_declaration(var4, extern=True)
 
 h.end_if_def()
 
@@ -137,10 +153,11 @@ c.include("main.h")
 
 c.add_line()
 
-# initialize those declared variables 
+# initialize those declared variables
 c.add_variable_initialization(var1)
 c.add_variable_initialization(var2)
 c.add_variable_initialization(var3)
+c.add_variable_initialization(var4)
 
 c.add_line()
 c.add_line(comment="Main function")

--- a/example.py
+++ b/example.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 from csnake import *
 
 # generate a header file


### PR DESCRIPTION
Added [designated initializers](https://gcc.gnu.org/onlinedocs/gcc/Designated-Inits.html) for structs, fixed up the comments. Added examples.

All that remains to be done is fixing up structs and enums, so they aren't always typedefed. It is often benefitial to see that something is definitely a struct or enum.